### PR TITLE
feat: add context (ctx) as reserved param for shared services via Arc<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Tools-rs is a framework for building, registering, and executing tools with auto
 - **Manual Registration** - Programmatic tool registration for dynamic scenarios
 - **Inventory System** - Link-time tool collection using the `inventory` crate for zero-runtime-cost discovery
 - **Typed Metadata** - Attach `#[tool(key = value)]` attributes to tools and read them through a user-defined `M` type on `ToolCollection<M>` (see [Tool Metadata](#tool-metadata))
+- **Shared Context** - Inject shared resources (`Arc<T>`) into tools via `ctx` first parameter and `ToolCollection::builder().with_context(...)` (see [Shared Context](#shared-context))
 
 ## Quick Start
 
@@ -317,6 +318,127 @@ tools.register(
 # Ok::<(), tools_rs::ToolError>(())
 ```
 
+## Shared Context
+
+Tools often need access to shared resources — database connections, HTTP
+clients, caches. If a tool's **first parameter is named `ctx`**, the macro
+treats it as a shared context that the collection injects at call time.
+Callers only pass the "real" arguments; `ctx` never appears in the JSON
+schema.
+
+```rust
+use std::sync::Arc;
+use tools_rs::{tool, ToolCollection, FunctionCall};
+use tools_core::NoMeta;
+
+struct Db {
+    url: String,
+}
+
+#[tool]
+/// Look up a user by name.
+async fn find_user(ctx: Db, name: String) -> String {
+    format!("[{}] SELECT * FROM users WHERE name = '{name}'", ctx.url)
+}
+
+#[tool]
+/// A plain tool — no context needed.
+async fn ping() -> String { "pong".into() }
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let db = Arc::new(Db { url: "postgres://localhost/app".into() });
+
+    let tools = ToolCollection::<NoMeta>::builder()
+        .with_context(db)
+        .collect()?;
+
+    // Caller never mentions ctx — only the "real" args:
+    let resp = tools.call(FunctionCall::new(
+        "find_user".into(),
+        serde_json::json!({ "name": "Alice" }),
+    )).await?;
+    println!("{}", resp.result);
+    Ok(())
+}
+```
+
+### How it works
+
+1. **Macro detection** — if the first parameter is named `ctx`, it is
+   excluded from the JSON schema wrapper struct. The macro rewrites the
+   emitted function signature from `ctx: T` to `ctx: Arc<T>` so that field
+   access and method calls work via `Deref`.
+2. **Builder** — `ToolCollection::builder().with_context(arc).collect()`
+   stores the `Arc<T>` and validates at startup that every context-requiring
+   tool expects the same type (via `TypeId` comparison). A mismatch produces
+   a clear `CtxTypeMismatch` error.
+3. **Call-time injection** — `collection.call(...)` passes the stored
+   context into the closure. Non-context tools ignore it.
+
+### Important: write `ctx: T`, not `ctx: Arc<T>`
+
+The macro wraps the type in `Arc` automatically. Writing `ctx: Arc<T>`
+produces a compile error to prevent accidental double-wrapping.
+
+### Interior mutability
+
+`Arc<T>` is immutable, but you can wrap an interior-mutable type:
+
+```rust
+use std::sync::Mutex;
+# use tools_rs::tool;
+
+struct Cache { entries: Vec<String> }
+
+#[tool]
+/// Record a cache hit.
+async fn record(ctx: Mutex<Cache>, key: String) -> String {
+    ctx.lock().unwrap().entries.push(key.clone());
+    format!("recorded {key}")
+}
+```
+
+The builder receives `Arc::new(Mutex::new(cache))`. The tool sees
+`Arc<Mutex<Cache>>` via Deref, so `ctx.lock()` works directly.
+
+### Context + metadata
+
+Context and metadata are orthogonal. Combine them freely:
+
+```rust
+# use std::sync::Arc;
+# use serde::Deserialize;
+# use tools_rs::{tool, ToolCollection};
+# struct Db { url: String }
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct Policy { requires_approval: bool }
+
+#[tool(requires_approval = true)]
+/// Drop a table — requires approval.
+async fn drop_table(ctx: Db, table: String) -> String {
+    format!("[{}] DROP TABLE {table}", ctx.url)
+}
+
+# fn example() -> Result<(), tools_rs::ToolError> {
+let tools = ToolCollection::<Policy>::builder()
+    .with_context(Arc::new(Db { url: "pg://localhost".into() }))
+    .collect()?;
+
+let meta = tools.meta("drop_table").unwrap();
+assert!(meta.requires_approval);
+# Ok(())
+# }
+```
+
+### Without context
+
+`collect_tools()` and `ToolCollection::collect_tools()` still work for
+collections that don't need context. If any tool in the inventory requires
+context and you call `collect_tools()` without the builder, it fails with
+`ToolError::MissingCtx` at startup.
+
 ## Examples
 
 Check out the [examples directory](examples/) for comprehensive sample code:
@@ -333,6 +455,12 @@ cargo run --example schema
 
 # Run the newtype demo - custom type wrapping examples
 cargo run --example newtype_demo
+
+# Run the HITL example - human-in-the-loop approval gating with metadata
+cargo run --example hitl
+
+# Run the context example - shared context injection
+cargo run --example context
 ```
 
 Each example demonstrates different aspects of the framework:
@@ -341,6 +469,8 @@ Each example demonstrates different aspects of the framework:
 - **function_declarations**: Complete LLM integration workflow with JSON schema generation
 - **schema**: Advanced schema generation for complex nested types and collections
 - **newtype_demo**: Working with custom wrapper types and serialization patterns
+- **hitl**: Human-in-the-loop approval gating using typed metadata
+- **context**: Shared context injection via `ToolCollection::builder().with_context(...)`
 
 ## API Reference
 
@@ -355,17 +485,20 @@ Each example demonstrates different aspects of the framework:
 
 ### Core Types
 
-- `ToolCollection` - Container for registered tools with execution capabilities
+- `ToolCollection<M>` - Container for registered tools, generic over metadata type `M` (defaults to `NoMeta`)
+- `CollectionBuilder<M>` - Builder for constructing collections with shared context
+- `ToolEntry<M>` - A single tool entry with its function, declaration, and metadata
 - `FunctionCall` - Represents a tool invocation with id, name, and arguments
 - `FunctionResponse` - Represents the response of a tool invocation with matching id to call, name, and result
 - `ToolError` - Comprehensive error type for tool operations
+- `NoMeta` - Default metadata type that ignores all `#[tool(...)]` attributes
 - `ToolSchema` - Trait for automatic JSON schema generation
 - `ToolRegistration` - Internal representation of registered tools
 - `FunctionDecl` - LLM-compatible function declaration structure
 
 ### Macros
 
-- `#[tool]` - Attribute macro for automatic tool registration
+- `#[tool]` - Attribute macro for automatic tool registration. Accepts flat `key = value` attributes for metadata. Detects `ctx` as a reserved first parameter for shared context injection.
 - `#[derive(ToolSchema)]` - Derive macro for automatic schema generation
 
 ## Error Handling

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -48,3 +48,7 @@ path = "chatbot/main.rs"
 [[example]]
 name = "hitl"
 path = "hitl/main.rs"
+
+[[example]]
+name = "context"
+path = "context/main.rs"

--- a/examples/context/main.rs
+++ b/examples/context/main.rs
@@ -1,7 +1,7 @@
 //! Shared context injection via `ToolCollection::builder().with_context(...)`.
 //!
-//! Tools that declare `ctx: Arc<T>` as their first parameter receive the
-//! shared context automatically at call time. The caller only passes the
+//! Tools that declare `ctx: T` as their first parameter receive an injected
+//! `Arc<T>` shared context automatically at call time. The caller only passes the
 //! "real" arguments — context injection is invisible at the call site.
 //!
 //! Run with:

--- a/examples/context/main.rs
+++ b/examples/context/main.rs
@@ -1,0 +1,112 @@
+//! Shared context injection via `ToolCollection::builder().with_context(...)`.
+//!
+//! Tools that declare `ctx: Arc<T>` as their first parameter receive the
+//! shared context automatically at call time. The caller only passes the
+//! "real" arguments — context injection is invisible at the call site.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example context
+//! ```
+
+use std::sync::Arc;
+
+use serde_json::json;
+use tools_core::{NoMeta, ToolCollection};
+use tools_rs::{FunctionCall, tool};
+
+// ---------- shared context ----------
+
+struct Context {
+    mailer_url: String,
+    db_name: String,
+}
+
+impl Context {
+    fn build() -> Arc<Self> {
+        Arc::new(Context {
+            mailer_url: "smtp://mail.example.com".into(),
+            db_name: "app_production".into(),
+        })
+    }
+}
+
+// ---------- tools that use context ----------
+
+#[tool]
+/// Sends an email via the configured mailer.
+async fn send_email(ctx: Context, address: String, subject: String, body: String) -> String {
+    format!(
+        "[{}] sent to {address}: \"{subject}\" — {}",
+        ctx.mailer_url, body
+    )
+}
+
+#[tool]
+/// Queries the database for a user by name.
+async fn find_user(ctx: Context, name: String) -> String {
+    format!(
+        "[{}] SELECT * FROM users WHERE name = '{name}'",
+        ctx.db_name
+    )
+}
+
+// ---------- tools that don't need context ----------
+
+#[tool]
+/// Returns the current server time.
+async fn server_time() -> String {
+    "2026-04-12T10:30:00Z (pretend)".into()
+}
+
+// ---------- driver ----------
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = Context::build();
+
+    let tools = ToolCollection::<NoMeta>::builder()
+        .with_context(ctx)
+        .collect()?;
+
+    println!("registered tools:");
+    let mut names: Vec<&str> = tools.iter().map(|(n, _)| n).collect();
+    names.sort_unstable();
+    for name in &names {
+        let needs_ctx = if tools.get(name).unwrap().decl.parameters["properties"]
+            .get("ctx")
+            .is_none()
+            && tools.get(name).unwrap().decl.parameters["properties"]
+                .as_object()
+                .map_or(true, |p| !p.is_empty())
+        {
+            ""
+        } else {
+            " (no args)"
+        };
+        println!("  - {name}{needs_ctx}");
+    }
+
+    // Simulate an LLM calling tools — caller never mentions ctx.
+    let calls: Vec<FunctionCall> = vec![
+        FunctionCall::new(
+            "send_email".into(),
+            json!({
+                "address": "m@example.com",
+                "subject": "Greetings",
+                "body": "Nice to meet you"
+            }),
+        ),
+        FunctionCall::new("find_user".into(), json!({ "name": "Alice" })),
+        FunctionCall::new("server_time".into(), json!({})),
+    ];
+
+    for call in calls {
+        println!("\n> calling `{}`", call.name);
+        let resp = tools.call(call).await?;
+        println!("  result: {}", resp.result);
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,9 +50,8 @@
 
 // Re-export core functionality
 pub use tools_core::{
-    DeserializationError, FunctionCall, FunctionDecl, FunctionResponse, ToolCollection, ToolError,
-    ToolMetadata, ToolRegistration, TypeSignature,
-    CallId
+    CallId, CollectionBuilder, DeserializationError, FunctionCall, FunctionDecl, FunctionResponse,
+    ToolCollection, ToolError, ToolMetadata, ToolRegistration, TypeSignature,
 };
 
 // Re-export schema functionality (trait from tools_core)

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -15,8 +15,8 @@ pub use crate::{
 
 // Essential types
 pub use crate::{
-    CallId, FunctionCall, FunctionDecl, FunctionResponse, ToolCollection, ToolError, ToolMetadata,
-    ToolSchema,
+    CallId, CollectionBuilder, FunctionCall, FunctionDecl, FunctionResponse, ToolCollection,
+    ToolError, ToolMetadata, ToolSchema,
 };
 
 // Macros

--- a/tests/context.rs
+++ b/tests/context.rs
@@ -1,0 +1,212 @@
+//! Tests for shared context (`Arc<T>`) injection via `CollectionBuilder`.
+//!
+//! Each integration-test file has its own `inventory`, so the tools
+//! declared here don't leak into the metadata tests or vice-versa.
+
+use std::sync::Arc;
+
+use serde::Deserialize;
+use tools_core::{NoMeta, ToolCollection, ToolError};
+use tools_rs::{tool, FunctionCall};
+
+// ---------- shared state ----------
+
+struct AppState {
+    greeting: String,
+}
+
+// ---------- tools ----------
+
+#[tool]
+/// Greets someone using the shared AppState.
+async fn greet(ctx: Arc<AppState>, name: String) -> String {
+    format!("{}, {}!", ctx.greeting, name)
+}
+
+#[tool]
+/// A plain tool that doesn't need context.
+async fn echo(msg: String) -> String {
+    msg
+}
+
+// ---------- happy path ----------
+
+#[tokio::test]
+async fn builder_injects_context_into_tool() {
+    let state = Arc::new(AppState {
+        greeting: "Howdy".into(),
+    });
+    let tools = ToolCollection::<NoMeta>::builder()
+        .with_context(state)
+        .collect()
+        .expect("collect with ctx");
+
+    let resp = tools
+        .call(FunctionCall::new(
+            "greet".into(),
+            serde_json::json!({ "name": "Alice" }),
+        ))
+        .await
+        .expect("call greet");
+
+    assert_eq!(resp.result, serde_json::json!("Howdy, Alice!"));
+}
+
+// ---------- mixed collection (ctx + non-ctx) ----------
+
+#[tokio::test]
+async fn mixed_collection_ctx_and_non_ctx() {
+    let state = Arc::new(AppState {
+        greeting: "Hi".into(),
+    });
+    let tools = ToolCollection::<NoMeta>::builder()
+        .with_context(state)
+        .collect()
+        .expect("mixed collect");
+
+    // ctx tool works
+    let resp = tools
+        .call(FunctionCall::new(
+            "greet".into(),
+            serde_json::json!({ "name": "Bob" }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.result, serde_json::json!("Hi, Bob!"));
+
+    // non-ctx tool works too
+    let resp = tools
+        .call(FunctionCall::new(
+            "echo".into(),
+            serde_json::json!({ "msg": "ping" }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.result, serde_json::json!("ping"));
+}
+
+// ---------- collect_tools() rejects ctx tools ----------
+
+#[test]
+fn collect_tools_rejects_ctx_tools() {
+    let result = ToolCollection::<NoMeta>::collect_tools();
+    let err = match result {
+        Ok(_) => panic!("expected MissingCtx error"),
+        Err(e) => e,
+    };
+    match err {
+        ToolError::MissingCtx { tool } => {
+            assert_eq!(tool, "greet");
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+// ---------- type mismatch ----------
+
+#[test]
+fn builder_rejects_wrong_ctx_type() {
+    let wrong_ctx: Arc<i32> = Arc::new(42);
+    let result = ToolCollection::<NoMeta>::builder()
+        .with_context(wrong_ctx)
+        .collect();
+    let err = match result {
+        Ok(_) => panic!("expected CtxTypeMismatch"),
+        Err(e) => e,
+    };
+    match err {
+        ToolError::CtxTypeMismatch {
+            tool,
+            expected,
+            got,
+        } => {
+            assert_eq!(tool, "greet");
+            assert!(expected.contains("AppState"), "expected={expected}");
+            assert!(got.contains("i32"), "got={got}");
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+// ---------- programmatic register into ctx collection ----------
+
+#[tokio::test]
+async fn register_non_ctx_tool_into_ctx_collection() {
+    let state = Arc::new(AppState {
+        greeting: "Hey".into(),
+    });
+    let mut tools = ToolCollection::<NoMeta>::builder()
+        .with_context(state)
+        .collect()
+        .unwrap();
+
+    tools
+        .register(
+            "double",
+            "Doubles a number",
+            |n: (i32,)| async move { n.0 * 2 },
+            (),
+        )
+        .unwrap();
+
+    let resp = tools
+        .call(FunctionCall::new(
+            "double".into(),
+            serde_json::json!([7]),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.result, serde_json::json!(14));
+}
+
+// ---------- JSON schema excludes ctx ----------
+
+#[test]
+fn json_schema_excludes_ctx_param() {
+    let state = Arc::new(AppState {
+        greeting: "Hi".into(),
+    });
+    let tools = ToolCollection::<NoMeta>::builder()
+        .with_context(state)
+        .collect()
+        .unwrap();
+
+    let entry = tools.get("greet").expect("greet exists");
+    let params = &entry.decl.parameters;
+
+    // `name` should be present
+    assert!(
+        params["properties"]["name"].is_object(),
+        "name field missing from schema"
+    );
+    // `ctx` should NOT be present
+    assert!(
+        params["properties"].get("ctx").is_none(),
+        "ctx leaked into JSON schema: {params}"
+    );
+}
+
+// ---------- typed metadata + context together ----------
+
+#[derive(Debug, Default, Deserialize, Clone, Copy)]
+#[serde(default)]
+struct Policy {
+    requires_approval: bool,
+}
+
+#[test]
+fn metadata_and_context_work_together() {
+    let state = Arc::new(AppState {
+        greeting: "Hello".into(),
+    });
+    let tools = ToolCollection::<Policy>::builder()
+        .with_context(state)
+        .collect()
+        .expect("meta + ctx");
+
+    let greet_meta = tools.meta("greet").unwrap();
+    assert!(!greet_meta.requires_approval);
+
+    let echo_meta = tools.meta("echo").unwrap();
+    assert!(!echo_meta.requires_approval);
+}

--- a/tests/context.rs
+++ b/tests/context.rs
@@ -19,7 +19,7 @@ struct AppState {
 
 #[tool]
 /// Greets someone using the shared AppState.
-async fn greet(ctx: Arc<AppState>, name: String) -> String {
+async fn greet(ctx: AppState, name: String) -> String {
     format!("{}, {}!", ctx.greeting, name)
 }
 

--- a/tools_core/src/lib.rs
+++ b/tools_core/src/lib.rs
@@ -1,7 +1,12 @@
 #![deny(unsafe_code)]
 
 use core::fmt;
-use std::{borrow::Cow, collections::HashMap, sync::Arc};
+use std::{
+    any::{Any, TypeId},
+    borrow::Cow,
+    collections::HashMap,
+    sync::Arc,
+};
 
 use futures::{FutureExt, future::BoxFuture};
 use once_cell::sync::Lazy;
@@ -198,6 +203,16 @@ pub enum ToolError {
         errors: Vec<MetaValidationError>,
         summary: String,
     },
+
+    #[error("tool `{tool}` requires context but none was provided")]
+    MissingCtx { tool: &'static str },
+
+    #[error("tool `{tool}` expects context type `{expected}` but collection has `{got}`")]
+    CtxTypeMismatch {
+        tool: &'static str,
+        expected: String,
+        got: String,
+    },
 }
 
 /// Specific deserialization errors
@@ -319,7 +334,10 @@ impl fmt::Display for FunctionResponse {
 }
 
 /// Function signature for tools
-pub type ToolFunc = dyn Fn(Value) -> BoxFuture<'static, Result<Value, ToolError>> + Send + Sync;
+pub type ToolFunc = dyn Fn(Value, Option<Arc<dyn Any + Send + Sync>>)
+    -> BoxFuture<'static, Result<Value, ToolError>>
+    + Send
+    + Sync;
 
 /// Metadata about a tool function
 #[derive(Debug, Clone)]
@@ -366,12 +384,23 @@ impl MetaArg<NoMeta> for () {
 pub struct ToolRegistration {
     pub name: &'static str,
     pub doc: &'static str,
-    pub f: fn(Value) -> BoxFuture<'static, Result<Value, ToolError>>,
+    pub f: fn(
+        Value,
+        Option<Arc<dyn Any + Send + Sync>>,
+    ) -> BoxFuture<'static, Result<Value, ToolError>>,
     pub param_schema: fn() -> Value,
     /// JSON object literal of the attributes declared in `#[tool(...)]`.
     /// `"{}"` when no attributes were given. Deserialized into the
     /// collection's `M` at [`ToolCollection::collect_tools`] time.
     pub meta_json: &'static str,
+    /// `true` when the tool's first parameter is named `ctx`.
+    pub needs_ctx: bool,
+    /// Returns the [`TypeId`] of the expected context type `T` (the inner
+    /// type of `Arc<T>`). `None` when `needs_ctx` is `false`.
+    pub ctx_type_id: Option<fn() -> TypeId>,
+    /// Human-readable name of the expected context type, for error
+    /// messages. Empty string when `needs_ctx` is `false`.
+    pub ctx_type_name: &'static str,
 }
 
 /// Per-tool attribute validation error. Reported by
@@ -459,12 +488,14 @@ impl<M: Clone> Clone for ToolEntry<M> {
 /// ```
 pub struct ToolCollection<M = NoMeta> {
     entries: HashMap<&'static str, ToolEntry<M>>,
+    ctx: Option<Arc<dyn Any + Send + Sync>>,
 }
 
 impl<M> Default for ToolCollection<M> {
     fn default() -> Self {
         Self {
             entries: HashMap::new(),
+            ctx: None,
         }
     }
 }
@@ -473,6 +504,7 @@ impl<M: Clone> Clone for ToolCollection<M> {
     fn clone(&self) -> Self {
         Self {
             entries: self.entries.clone(),
+            ctx: self.ctx.clone(),
         }
     }
 }
@@ -480,6 +512,17 @@ impl<M: Clone> Clone for ToolCollection<M> {
 impl<M> ToolCollection<M> {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Create a [`CollectionBuilder`] for constructing a collection with
+    /// shared context and/or custom configuration.
+    pub fn builder() -> CollectionBuilder<M> {
+        CollectionBuilder {
+            ctx: None,
+            ctx_type_id: None,
+            ctx_type_name: "",
+            _meta: std::marker::PhantomData,
+        }
     }
 
     /// Register a tool programmatically. Pass `()` as `meta` for
@@ -505,7 +548,9 @@ impl<M> ToolCollection<M> {
 
         let func_arc: Arc<F> = Arc::new(func);
         let boxed: Arc<ToolFunc> = Arc::new(
-            move |raw: Value| -> BoxFuture<'static, Result<Value, ToolError>> {
+            move |raw: Value,
+                  _ctx: Option<Arc<dyn Any + Send + Sync>>|
+                  -> BoxFuture<'static, Result<Value, ToolError>> {
                 let func = func_arc.clone();
                 async move {
                     let input: I =
@@ -542,7 +587,7 @@ impl<M> ToolCollection<M> {
                 name: Cow::Owned(name.clone()),
             })?;
 
-        let result = (entry.func)(arguments).await?;
+        let result = (entry.func)(arguments, self.ctx.clone()).await?;
         Ok(FunctionResponse { id, name, result })
     }
 
@@ -586,6 +631,10 @@ impl<M: DeserializeOwned> ToolCollection<M> {
         let mut hub = Self::new();
 
         for reg in inventory::iter::<ToolRegistration> {
+            if reg.needs_ctx {
+                return Err(ToolError::MissingCtx { tool: reg.name });
+            }
+
             let meta: M = serde_json::from_str(reg.meta_json).map_err(|e| ToolError::BadMeta {
                 tool: reg.name,
                 error: e.to_string(),
@@ -666,6 +715,85 @@ pub fn validate_tool_attrs_for<M: DeserializeOwned>(
 }
 
 inventory::collect!(ToolRegistration);
+
+// ============================================================================
+// COLLECTION BUILDER
+// ============================================================================
+
+/// Builder for [`ToolCollection`] with support for shared context
+/// injection. Construct via [`ToolCollection::builder()`].
+///
+/// ```ignore
+/// let ctx = Arc::new(MyState::new());
+/// let tools = ToolCollection::<Policy>::builder()
+///     .with_context(ctx)
+///     .collect()?;
+/// ```
+pub struct CollectionBuilder<M = NoMeta> {
+    ctx: Option<Arc<dyn Any + Send + Sync>>,
+    ctx_type_id: Option<TypeId>,
+    ctx_type_name: &'static str,
+    _meta: std::marker::PhantomData<M>,
+}
+
+impl<M> CollectionBuilder<M> {
+    /// Attach a shared context that will be injected into every tool whose
+    /// first parameter is named `ctx`. The context type `T` must match what
+    /// the tools expect — a mismatch is caught at [`collect()`][Self::collect]
+    /// time with a clear error.
+    pub fn with_context<T: Send + Sync + 'static>(mut self, ctx: Arc<T>) -> Self {
+        self.ctx_type_id = Some(TypeId::of::<T>());
+        self.ctx_type_name = std::any::type_name::<T>();
+        self.ctx = Some(ctx);
+        self
+    }
+}
+
+impl<M: DeserializeOwned> CollectionBuilder<M> {
+    /// Build the collection from the global tool inventory. Validates:
+    ///
+    /// - Every tool's `meta_json` deserializes into `M`.
+    /// - Every `needs_ctx` tool's expected `TypeId` matches the builder's.
+    /// - No `needs_ctx` tool exists when no context was provided.
+    pub fn collect(self) -> Result<ToolCollection<M>, ToolError> {
+        let mut entries = HashMap::new();
+
+        for reg in inventory::iter::<ToolRegistration> {
+            if reg.needs_ctx {
+                let Some(provided_id) = self.ctx_type_id else {
+                    return Err(ToolError::MissingCtx { tool: reg.name });
+                };
+                let expected_id = (reg.ctx_type_id.unwrap())();
+                if expected_id != provided_id {
+                    return Err(ToolError::CtxTypeMismatch {
+                        tool: reg.name,
+                        expected: reg.ctx_type_name.to_string(),
+                        got: self.ctx_type_name.to_string(),
+                    });
+                }
+            }
+
+            let meta: M = serde_json::from_str(reg.meta_json).map_err(|e| ToolError::BadMeta {
+                tool: reg.name,
+                error: e.to_string(),
+            })?;
+
+            entries.insert(
+                reg.name,
+                ToolEntry {
+                    func: Arc::new(reg.f),
+                    decl: FunctionDecl::new(reg.name, reg.doc, (reg.param_schema)()),
+                    meta,
+                },
+            );
+        }
+
+        Ok(ToolCollection {
+            entries,
+            ctx: self.ctx,
+        })
+    }
+}
 
 // ============================================================================
 // TESTS

--- a/tools_macros/src/lib.rs
+++ b/tools_macros/src/lib.rs
@@ -253,8 +253,16 @@ pub fn tool(attr: TokenStream, item: TokenStream) -> TokenStream {
         .first()
         .map_or(false, |(ident, _)| ident == "ctx")
     {
-        let ctx_ty = all_params[0].1.clone();
-        (Some(ctx_ty), all_params[1..].to_vec())
+        let ctx_ty = &all_params[0].1;
+        // Reject `ctx: Arc<T>` — we wrap in Arc internally, so the user
+        // must write `ctx: T` (not `ctx: Arc<T>`).
+        if is_arc_type(ctx_ty) {
+            abort!(
+                ctx_ty,
+                "`ctx` must be typed as `T`, not `Arc<T>` — the `#[tool]` macro wraps it in `Arc` automatically"
+            );
+        }
+        (Some(ctx_ty.clone()), all_params[1..].to_vec())
     } else {
         (None, all_params)
     };
@@ -462,6 +470,17 @@ fn attr_expr_to_json(e: &Expr) -> serde_json::Value {
         },
         _ => abort!(e, "attribute values must be bool/int/float/string literals"),
     }
+}
+
+/// Returns `true` if the type looks like `Arc<_>` (or `std::sync::Arc<_>`).
+fn is_arc_type(ty: &Type) -> bool {
+    if let Type::Path(TypePath { path, .. }) = ty {
+        if let Some(last) = path.segments.last() {
+            return last.ident == "Arc"
+                && matches!(last.arguments, syn::PathArguments::AngleBracketed(_));
+        }
+    }
+    false
 }
 
 #[cfg(test)]

--- a/tools_macros/src/lib.rs
+++ b/tools_macros/src/lib.rs
@@ -230,7 +230,8 @@ pub fn tool(attr: TokenStream, item: TokenStream) -> TokenStream {
     let doc_lit = LitStr::new(&docs(&func.attrs), Span::call_site());
 
     // ───────── Inputs → wrapper struct fields ─────────
-    let (idents, types): (Vec<_>, Vec<_>) = func
+    // Detect reserved `ctx` first parameter.
+    let all_params: Vec<_> = func
         .sig
         .inputs
         .iter()
@@ -243,12 +244,74 @@ pub fn tool(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
             _ => abort!(arg, "`#[tool]` may not be used on `self` methods"),
         })
-        .unzip();
+        .collect();
+
+    // If the first parameter is named `ctx`, treat it as context injection.
+    let (ctx_inner_ty, param_pairs) = if all_params
+        .first()
+        .map_or(false, |(ident, _)| ident == "ctx")
+    {
+        let ctx_ty = &all_params[0].1;
+        let inner = extract_arc_inner(ctx_ty);
+        (Some(inner), all_params[1..].to_vec())
+    } else {
+        (None, all_params)
+    };
+
+    let (idents, types): (Vec<_>, Vec<_>) = param_pairs.into_iter().unzip();
 
     // ───────── Generated helper idents ─────────
     let wrapper_ident = Ident::new(&format!("__TOOL_INPUT_{fn_name}"), Span::call_site());
     let schema_fn = Ident::new(&format!("__SCHEMA_FOR_{fn_name}"), Span::call_site());
     let crate_path = get_crate_path();
+
+    // ───────── Context-dependent codegen ─────────
+    let (closure_body, needs_ctx_lit, ctx_type_id_expr, ctx_type_name_lit) =
+        if let Some(ref inner_ty) = ctx_inner_ty {
+            let type_name_str = quote!(#inner_ty).to_string();
+            let type_name_lit = LitStr::new(&type_name_str, Span::call_site());
+            (
+                quote! {
+                    |v, ctx_opt| ::std::boxed::Box::pin(async move {
+                        let ctx_any = ctx_opt.ok_or_else(|| #crate_path::ToolError::MissingCtx {
+                            tool: #fn_name_str,
+                        })?;
+                        let ctx: ::std::sync::Arc<#inner_ty> =
+                            ctx_any.downcast::<#inner_ty>().map_err(|_| {
+                                #crate_path::ToolError::Runtime(
+                                    "context downcast failed".to_string(),
+                                )
+                            })?;
+                        let arg: #wrapper_ident =
+                            ::serde_json::from_value(v)
+                                .map_err(#crate_path::DeserializationError::from)?;
+                        let out = #fn_name(ctx, #( arg.#idents ),* ).await;
+                        ::serde_json::to_value(out)
+                            .map_err(|e| #crate_path::ToolError::Runtime(e.to_string()))
+                    })
+                },
+                quote!(true),
+                quote!(Some(|| ::std::any::TypeId::of::<#inner_ty>())),
+                type_name_lit,
+            )
+        } else {
+            let empty_name = LitStr::new("", Span::call_site());
+            (
+                quote! {
+                    |v, _ctx| ::std::boxed::Box::pin(async move {
+                        let arg: #wrapper_ident =
+                            ::serde_json::from_value(v)
+                                .map_err(#crate_path::DeserializationError::from)?;
+                        let out = #fn_name( #( arg.#idents ),* ).await;
+                        ::serde_json::to_value(out)
+                            .map_err(|e| #crate_path::ToolError::Runtime(e.to_string()))
+                    })
+                },
+                quote!(false),
+                quote!(None),
+                empty_name,
+            )
+        };
 
     // ───────── Macro expansion ─────────
     TokenStream::from(quote! {
@@ -267,19 +330,37 @@ pub fn tool(attr: TokenStream, item: TokenStream) -> TokenStream {
             #crate_path::ToolRegistration {
                 name: #fn_name_str,
                 doc: #doc_lit,
-                f: |v| ::std::boxed::Box::pin(async move {
-                    let arg: #wrapper_ident =
-                        ::serde_json::from_value(v)
-                            .map_err(#crate_path::DeserializationError::from)?;
-                    let out = #fn_name( #( arg.#idents ),* ).await;
-                    ::serde_json::to_value(out)
-                        .map_err(|e| #crate_path::ToolError::Runtime(e.to_string()))
-                }),
+                f: #closure_body,
                 param_schema: || #schema_fn::<#wrapper_ident>(),
                 meta_json: #meta_lit,
+                needs_ctx: #needs_ctx_lit,
+                ctx_type_id: #ctx_type_id_expr,
+                ctx_type_name: #ctx_type_name_lit,
             }
         }
     })
+}
+
+/// Extract the inner type `T` from `Arc<T>`. Aborts if the type doesn't
+/// look like `Arc<...>` (or `std::sync::Arc<...>`).
+fn extract_arc_inner(ty: &Type) -> Type {
+    if let Type::Path(TypePath { path, .. }) = ty {
+        let last = path.segments.last().unwrap_or_else(|| {
+            abort!(ty, "`ctx` parameter must be typed `Arc<T>`");
+        });
+        if last.ident == "Arc" {
+            if let syn::PathArguments::AngleBracketed(args) = &last.arguments {
+                if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
+                    return inner.clone();
+                }
+            }
+        }
+    }
+    abort!(
+        ty,
+        "`ctx` parameter must be typed `Arc<T>`, found `{}`",
+        quote!(#ty)
+    );
 }
 
 /// Parse `#[tool(key = value, key2 = value2, flag, ...)]` into a JSON

--- a/tools_macros/src/lib.rs
+++ b/tools_macros/src/lib.rs
@@ -247,13 +247,14 @@ pub fn tool(attr: TokenStream, item: TokenStream) -> TokenStream {
         .collect();
 
     // If the first parameter is named `ctx`, treat it as context injection.
+    // The user writes `ctx: T`; we rewrite the emitted fn to `ctx: Arc<T>`
+    // so that field access and method calls work via Deref.
     let (ctx_inner_ty, param_pairs) = if all_params
         .first()
         .map_or(false, |(ident, _)| ident == "ctx")
     {
-        let ctx_ty = &all_params[0].1;
-        let inner = extract_arc_inner(ctx_ty);
-        (Some(inner), all_params[1..].to_vec())
+        let ctx_ty = all_params[0].1.clone();
+        (Some(ctx_ty), all_params[1..].to_vec())
     } else {
         (None, all_params)
     };
@@ -313,9 +314,23 @@ pub fn tool(attr: TokenStream, item: TokenStream) -> TokenStream {
             )
         };
 
+    // ───────── Rewrite fn signature if ctx detected ─────────
+    // User wrote `ctx: T`, emit `ctx: Arc<T>` so Deref covers .field / .method().
+    let emitted_func = if let Some(ref inner_ty) = ctx_inner_ty {
+        let mut func_out = func.clone();
+        if let Some(first_arg) = func_out.sig.inputs.first_mut() {
+            if let FnArg::Typed(pat_type) = first_arg {
+                pat_type.ty = Box::new(syn::parse_quote!(::std::sync::Arc<#inner_ty>));
+            }
+        }
+        func_out
+    } else {
+        func
+    };
+
     // ───────── Macro expansion ─────────
     TokenStream::from(quote! {
-        #func
+        #emitted_func
 
         #[allow(non_camel_case_types)]
         #[derive(::serde::Deserialize, tools_macros::ToolSchema)]
@@ -339,28 +354,6 @@ pub fn tool(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         }
     })
-}
-
-/// Extract the inner type `T` from `Arc<T>`. Aborts if the type doesn't
-/// look like `Arc<...>` (or `std::sync::Arc<...>`).
-fn extract_arc_inner(ty: &Type) -> Type {
-    if let Type::Path(TypePath { path, .. }) = ty {
-        let last = path.segments.last().unwrap_or_else(|| {
-            abort!(ty, "`ctx` parameter must be typed `Arc<T>`");
-        });
-        if last.ident == "Arc" {
-            if let syn::PathArguments::AngleBracketed(args) = &last.arguments {
-                if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
-                    return inner.clone();
-                }
-            }
-        }
-    }
-    abort!(
-        ty,
-        "`ctx` parameter must be typed `Arc<T>`, found `{}`",
-        quote!(#ty)
-    );
 }
 
 /// Parse `#[tool(key = value, key2 = value2, flag, ...)]` into a JSON


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tools can accept and use shared runtime context during execution
  * Builder-style API to create tool collections with optional context
  * Context parameters are automatically omitted from generated tool schemas

* **Bug Fixes / Reliability**
  * Clearer errors when context is missing or its type mismatches expected

* **Examples & Tests**
  * Added example and integration tests demonstrating context usage

* **Chores**
  * Public exports updated to expose context-related API changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->